### PR TITLE
Issue #16: Integrate extended CSV semantic indexer into deployment

### DIFF
--- a/deploy/helm/magda/Chart.lock
+++ b/deploy/helm/magda/Chart.lock
@@ -29,5 +29,11 @@ dependencies:
 - name: magda-function-esri-url-processor
   repository: oci://ghcr.io/magda-io/charts
   version: 2.0.0
-digest: sha256:40cd523ac5632f738e8f7f41df7cada91b2780fb8fd8d3d21fb236d22d80f574
-generated: "2025-12-24T00:45:36.839728248Z"
+- name: magda-pdf-semantic-indexer
+  repository: oci://ghcr.io/magda-io/charts
+  version: 1.0.0-alpha.1
+- name: magda-csv-semantic-indexer
+  repository: oci://ghcr.io/magda-io/charts
+  version: 1.0.0-alpha.0
+digest: sha256:b291d7d95acfbf2ddafbe9c9c4919278613d66719ead6559550a9f94f1839f90
+generated: "2026-04-18T15:11:55.93708+03:00"

--- a/deploy/helm/magda/Chart.yaml
+++ b/deploy/helm/magda/Chart.yaml
@@ -84,3 +84,15 @@ dependencies:
       - all
       - url-processors
       - magda-function-esri-url-processor
+
+  - name: magda-pdf-semantic-indexer
+    version: "1.0.0-alpha.1"
+    repository: "oci://ghcr.io/magda-io/charts"
+    tags:
+      - pdf-semantic-indexer
+
+  - name: magda-csv-semantic-indexer
+    version: "1.0.0-alpha.0"
+    repository: "oci://ghcr.io/magda-io/charts"
+    tags:
+      - csv-semantic-indexer

--- a/deploy/helm/magda/README.md
+++ b/deploy/helm/magda/README.md
@@ -16,6 +16,7 @@ A complete solution for managing, publishing and discovering government data, pr
 |------------|------|---------|
 | file://../magda-core | magda-core | 5.6.0 |
 | oci://ghcr.io/magda-io/charts | ckan-connector-functions(magda-ckan-connector) | 2.0.0 |
+| oci://ghcr.io/magda-io/charts | magda-csv-semantic-indexer | 1.0.0-alpha.0 |
 | oci://ghcr.io/magda-io/charts | magda-function-esri-url-processor | 2.0.0 |
 | oci://ghcr.io/magda-io/charts | magda-function-history-report | 2.0.0 |
 | oci://ghcr.io/magda-io/charts | minion-broken-link(magda-minion-broken-link) | 3.0.0 |
@@ -23,6 +24,7 @@ A complete solution for managing, publishing and discovering government data, pr
 | oci://ghcr.io/magda-io/charts | minion-format(magda-minion-format) | 2.0.1 |
 | oci://ghcr.io/magda-io/charts | minion-linked-data-rating(magda-minion-linked-data-rating) | 2.0.0 |
 | oci://ghcr.io/magda-io/charts | minion-visualization(magda-minion-visualization) | 2.0.0 |
+| oci://ghcr.io/magda-io/charts | magda-pdf-semantic-indexer | 1.0.0-alpha.1 |
 | oci://ghcr.io/magda-io/charts | openfaas | 5.5.5-magda.3 |
 
 ## Values


### PR DESCRIPTION
## Summary
- Re-add `magda-csv-semantic-indexer` and `magda-pdf-semantic-indexer` as dependencies of the main `magda` Helm chart.
- Update chart lock and requirements documentation so plugin dependencies are resolved and visible in the deployment pipeline.
- Keep plugin activation aligned with existing feature toggles (`tags.csv-semantic-indexer` and `tags.pdf-semantic-indexer`).

## Why this matters
- Makes the extended CSV semantic indexer available through normal MAGDA chart deployment flows.
- Ensures plugin charts are loaded consistently rather than requiring manual side-loading.

## Test plan
- [x] `helm dependency update deploy/helm/magda`
- [x] `helm dependency build deploy/helm/magda`
- [x] Targeted `.xlsx` semantic indexing tests passed in semantic indexer framework
- [ ] Deploy on cluster and verify plugin pod startup + `.xlsx` end-to-end indexing/searchability